### PR TITLE
Allow configuring invoice logo size from company data

### DIFF
--- a/html/company.html
+++ b/html/company.html
@@ -51,6 +51,12 @@
                         <label>Número inicial factura
                             <input type="text" name="invoiceNumbering" />
                         </label>
+                        <label>Ancho máximo logo (px)
+                            <input type="number" name="invoiceLogoMaxWidth" min="0" />
+                        </label>
+                        <label>Alto máximo logo (px)
+                            <input type="number" name="invoiceLogoMaxHeight" min="0" />
+                        </label>
                         <fieldset class="full company-logo">
                             <legend>Logo</legend>
                             <div class="company-logo__preview">

--- a/js/company.js
+++ b/js/company.js
@@ -117,6 +117,16 @@ function openCompanyModal(tmpl) {
     e.preventDefault();
     const data = sanitizeStrings(Object.fromEntries(new FormData(form).entries()));
     if (data.logo === "") data.logo = null;
+    ["invoiceLogoMaxWidth", "invoiceLogoMaxHeight"].forEach(field => {
+      if (!Object.prototype.hasOwnProperty.call(data, field)) return;
+      const value = data[field];
+      if (value === "" || value == null) {
+        data[field] = null;
+        return;
+      }
+      const parsed = Number.parseInt(value, 10);
+      data[field] = Number.isFinite(parsed) ? parsed : null;
+    });
     try {
       if (Object.prototype.hasOwnProperty.call(company, 'id')) {
         await db.update('company', { id: company.id }, data);

--- a/sql/add_company_logo_dimensions.sql
+++ b/sql/add_company_logo_dimensions.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.company
+    ADD COLUMN invoice_logo_max_width integer DEFAULT 220,
+    ADD COLUMN invoice_logo_max_height integer DEFAULT 220;


### PR DESCRIPTION
## Summary
- allow editing the invoice logo maximum width and height from the company modal
- load the configured dimensions into the invoice printout via CSS custom properties
- add SQL to create the new company fields for logo sizing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d414c464088330905253ef63cb4a21